### PR TITLE
splicing-unquote → unquote-splicing

### DIFF
--- a/ch-05/ch-05-1.md
+++ b/ch-05/ch-05-1.md
@@ -249,7 +249,7 @@ end
       '(recur)))
 ```
 
-- 이를 위해 문법 인용(syntax-quote), 평가 기호(unquote), 평가 이음 기호(splicing-unquote) 등 세가지 도구를 제공한다: 매크로만을 위해 정의된 기호들은 아니지만, 매크로 정의시에 가장 많이 사용됨
+- 이를 위해 문법 인용(syntax-quote), 평가 기호(unquote), 평가 이음 기호(unquote-splicing) 등 세가지 도구를 제공한다: 매크로만을 위해 정의된 기호들은 아니지만, 매크로 정의시에 가장 많이 사용됨
 
 ```Clojure
 (defmacro while 


### PR DESCRIPTION
p.240에는 splicing-unquote 이라고 되어 있는데, unquote-splicing가 더 통상적인 표기로 보이며, 책의 다른 부분에서는 모두 unquote-splicing으로 사용하고 있음. 다른 곳에서도 간혹 splicing-unquote 이 보이기는 하지만 unquote-splicing가 훨씬 많이 사용됨.
